### PR TITLE
Feature : Configuration (Size, Color) of input tools

### DIFF
--- a/src/lib/blocs/exams/exams_state.dart
+++ b/src/lib/blocs/exams/exams_state.dart
@@ -9,14 +9,9 @@ class ExamsState extends Equatable {
       : exams = [],
         filtered = [];
 
-  const ExamsState.unfiltered({required List<Exam> exams})
-      : this.exams = exams,
-        filtered = exams;
+  const ExamsState.unfiltered({required this.exams}) : filtered = exams;
 
-  const ExamsState.filtered(
-      {required List<Exam> exams, required List<Exam> filtered})
-      : this.exams = exams,
-        this.filtered = filtered;
+  const ExamsState.filtered({required this.exams, required this.filtered});
 
   @override
   List<Object> get props => [exams, filtered];

--- a/src/lib/components/correction/correction_input_header.dart
+++ b/src/lib/components/correction/correction_input_header.dart
@@ -2,43 +2,44 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:schoolexam/exams/exams.dart';
+import 'package:schoolexam_correction_ui/blocs/remark/correction.dart';
 import 'package:schoolexam_correction_ui/blocs/remark/remark.dart';
 
 import 'input/input_header.dart';
 
 class CorrectionInputHeader extends StatelessWidget {
-  const CorrectionInputHeader({Key? key}) : super(key: key);
+  final Exam exam;
+  final Correction correction;
+
+  const CorrectionInputHeader(
+      {Key? key,
+      required this.exam,
+      required this.correction})
+      : super(key: key);
 
   @override
-  Widget build(BuildContext context) =>
-      BlocBuilder<RemarkCubit, RemarkState>(builder: (context, state) {
-        return Container(
-          constraints: const BoxConstraints(maxHeight: 48),
-          child: Row(
-            children: [
-              DropdownButton(
-                  value: (state.corrections.isNotEmpty)
-                      ? (state.corrections[state.selectedCorrection]
-                              .currentAnswer.isNotEmpty)
-                          ? state.corrections[state.selectedCorrection]
-                              .currentAnswer.task.id
-                          : null
-                      : null,
-                  items: state.exam.tasks
-                      .map((e) => DropdownMenuItem(
-                            value: e.id,
-                            child: Text(e.title),
-                          ))
-                      .toList(),
-                  onChanged: (String? newValue) {
-                    final task = state.exam.tasks.firstWhere(
-                        (element) => element.id == newValue,
-                        orElse: () => Task.empty);
-                    BlocProvider.of<RemarkCubit>(context).moveTo(task);
-                  }),
-              const InputHeader()
-            ],
-          ),
-        );
-      });
+  Widget build(BuildContext context) => Container(
+        constraints: const BoxConstraints(maxHeight: 48),
+        child: Row(
+          children: [
+            DropdownButton(
+                value: (correction.currentAnswer.isNotEmpty)
+                    ? correction.currentAnswer.task.id
+                    : null,
+                items: exam.tasks
+                    .map((e) => DropdownMenuItem(
+                          value: e.id,
+                          child: Text(e.title),
+                        ))
+                    .toList(),
+                onChanged: (String? newValue) {
+                  final task = exam.tasks.firstWhere(
+                      (element) => element.id == newValue,
+                      orElse: () => Task.empty);
+                  BlocProvider.of<RemarkCubit>(context).moveTo(task);
+                }),
+            const InputHeader()
+          ],
+        ),
+      );
 }

--- a/src/lib/components/correction/correction_tab_view.dart
+++ b/src/lib/components/correction/correction_tab_view.dart
@@ -42,31 +42,54 @@ class CorrectionTabView extends StatelessWidget {
   @override
   Widget build(BuildContext context) =>
       BlocConsumer<CorrectionOverlayCubit, CorrectionOverlayState>(
+          listenWhen: (old, current) => current is! UpdatedInputOptionsState,
           listener: (context, state) => _update(state),
-          builder: (context, state) => StreamBuilder<CorrectionOverlayDocument>(
-              stream: documentController.stream,
-              initialData: _getDocument(state),
-              builder: (context, snapshot) {
-                if (!snapshot.hasData) {
-                  return const CircularProgressIndicator();
-                }
+          buildWhen: (old, current) => false,
+          builder: (context, state) => _CorrectionTabView(
+                correction: correction,
+                initial: _getDocument(state),
+                controller: documentController,
+              ));
+}
 
-                return Column(
-                  children: [
-                    Container(
-                      color: null,
-                      constraints: BoxConstraints(
-                          maxWidth: MediaQuery.of(context).size.width * 0.7),
-                      child: CorrectionPageView(
-                        correction: correction,
-                        initialDocument: snapshot.requireData,
-                        documentController: documentController,
-                      ),
-                    ),
-                    CorrectionPageNavigation(
-                      document: snapshot.requireData,
-                    )
-                  ],
-                );
-              }));
+class _CorrectionTabView extends StatelessWidget {
+  final Correction correction;
+  final CorrectionOverlayDocument initial;
+  final StreamController<CorrectionOverlayDocument> controller;
+
+  const _CorrectionTabView(
+      {Key? key,
+      required this.initial,
+      required this.controller,
+      required this.correction})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) =>
+      StreamBuilder<CorrectionOverlayDocument>(
+          stream: controller.stream,
+          initialData: initial,
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return const CircularProgressIndicator();
+            }
+
+            return Column(
+              children: [
+                Container(
+                  color: null,
+                  constraints: BoxConstraints(
+                      maxWidth: MediaQuery.of(context).size.width * 0.7),
+                  child: CorrectionPageView(
+                    correction: correction,
+                    initialDocument: snapshot.requireData,
+                    documentController: controller,
+                  ),
+                ),
+                CorrectionPageNavigation(
+                  document: snapshot.requireData,
+                )
+              ],
+            );
+          });
 }

--- a/src/lib/components/correction/correction_view.dart
+++ b/src/lib/components/correction/correction_view.dart
@@ -19,7 +19,11 @@ class CorrectionView extends StatelessWidget {
 
         return Column(
           children: [
-            const CorrectionInputHeader(),
+            // TODO TabView over all corrections
+            CorrectionInputHeader(
+              exam: state.exam,
+              correction: state.corrections[state.selectedCorrection],
+            ),
             Container(
                 color: null,
                 constraints: BoxConstraints(

--- a/src/lib/components/correction/input/colored_input_options.dart
+++ b/src/lib/components/correction/input/colored_input_options.dart
@@ -3,8 +3,19 @@ import 'dart:ui';
 import 'input_options.dart';
 
 class ColoredInputOptions extends InputOptions {
-  Color color;
+  final Color color;
 
-  ColoredInputOptions({required int size, required this.color})
+  const ColoredInputOptions({required int size, required this.color})
       : super(size: size);
+
+  @override
+  ColoredInputOptions copyWith({
+    int? size,
+    Color? color,
+  }) {
+    return ColoredInputOptions(
+      size: size ?? this.size,
+      color: color ?? this.color,
+    );
+  }
 }

--- a/src/lib/components/correction/input/drawing_input_options.dart
+++ b/src/lib/components/correction/input/drawing_input_options.dart
@@ -30,7 +30,7 @@ class DrawingInputOptions extends ColoredInputOptions {
   // Whether the line is complete.
   final bool isComplete;
 
-  DrawingInputOptions._(
+  const DrawingInputOptions._(
       {required this.thinning,
       required this.smoothing,
       required this.streamline,
@@ -44,7 +44,7 @@ class DrawingInputOptions extends ColoredInputOptions {
       required Color color})
       : super(size: size, color: color);
 
-  DrawingInputOptions.pencil({required int size, required Color color})
+  const DrawingInputOptions.pencil({required int size, required Color color})
       : this._(
             thinning: 0.7,
             smoothing: 0.5,
@@ -58,7 +58,7 @@ class DrawingInputOptions extends ColoredInputOptions {
             size: size,
             color: color);
 
-  DrawingInputOptions.marker({required int size, required Color color})
+  const DrawingInputOptions.marker({required int size, required Color color})
       : this._(
             thinning: 0.0,
             smoothing: 1.0,
@@ -70,8 +70,9 @@ class DrawingInputOptions extends ColoredInputOptions {
             simulatePressure: true,
             isComplete: false,
             size: size,
-            color: color.withOpacity(0.5));
+            color: color);
 
+  @override
   DrawingInputOptions copyWith({
     double? thinning,
     double? smoothing,

--- a/src/lib/components/correction/input/input_header.dart
+++ b/src/lib/components/correction/input/input_header.dart
@@ -2,7 +2,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:schoolexam_correction_ui/blocs/overlay/correction_overlay.dart';
+import 'package:schoolexam_correction_ui/components/correction/input/input_options.dart';
+import 'package:schoolexam_correction_ui/components/correction/settings/tool_settings_widget.dart';
 import 'package:schoolexam_correction_ui/presentation/custom_icons.dart';
+
+import 'colored_input_options.dart';
 
 class InputHeader extends StatelessWidget {
   const InputHeader({Key? key}) : super(key: key);
@@ -26,55 +30,149 @@ class InputHeader extends StatelessWidget {
                           .redo(document: state.overlays[state.documentNumber]);
                     },
                     icon: const Icon(Icons.redo)),
-                IconButton(
-                    onPressed: () {
-                      BlocProvider.of<CorrectionOverlayCubit>(context)
-                          .changeTool(CorrectionInputTool.text);
-                    },
-                    color: (state.inputTool == CorrectionInputTool.text)
-                        ? Theme.of(context).primaryColor
-                        : null,
-                    icon: const Icon(CustomIcons.font)),
-                IconButton(
-                    onPressed: () {
-                      BlocProvider.of<CorrectionOverlayCubit>(context)
-                          .changeTool(CorrectionInputTool.pencil);
-                    },
-                    color: (state.inputTool == CorrectionInputTool.pencil)
-                        ? Theme.of(context).primaryColor
-                        : null,
-                    icon: const Icon(CustomIcons.pencil_alt)),
-                IconButton(
-                    onPressed: () {
-                      BlocProvider.of<CorrectionOverlayCubit>(context)
-                          .changeTool(CorrectionInputTool.marker);
-                    },
-                    color: (state.inputTool == CorrectionInputTool.marker)
-                        ? Theme.of(context).primaryColor
-                        : null,
-                    icon: const Icon(CustomIcons.marker)),
-                IconButton(
-                    onPressed: () {
-                      BlocProvider.of<CorrectionOverlayCubit>(context)
-                          .changeTool(CorrectionInputTool.eraser);
-                    },
-                    color: (state.inputTool == CorrectionInputTool.eraser)
-                        ? Theme.of(context).primaryColor
-                        : null,
-                    icon: const Icon(CustomIcons.eraser)),
-                const Padding(
-                  padding: EdgeInsets.all(8.0),
-                  child: VerticalDivider(
-                    thickness: 2,
-                  ),
-                ),
-                IconButton(
-                    onPressed: () {},
-                    icon: const Icon(
-                      Icons.circle,
-                      color: Colors.black,
-                    )),
+                const _InputIconButton(
+                    icon: Icon(CustomIcons.font),
+                    tool: CorrectionInputTool.text),
+                const _InputIconButton(
+                    icon: Icon(CustomIcons.pencil_alt),
+                    tool: CorrectionInputTool.pencil),
+                const _InputIconButton(
+                    icon: Icon(CustomIcons.marker),
+                    tool: CorrectionInputTool.marker),
+                const _InputIconButton(
+                    icon: Icon(CustomIcons.eraser),
+                    tool: CorrectionInputTool.eraser),
+                _InputSettingsWidget(
+                  tool: state.inputTool,
+                )
               ],
             )),
       );
+}
+
+class _InputIconButton extends StatelessWidget {
+  final CorrectionInputTool tool;
+  final Icon icon;
+
+  const _InputIconButton({Key? key, required this.tool, required this.icon})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) =>
+      BlocBuilder<CorrectionOverlayCubit, CorrectionOverlayState>(
+          builder: (context, state) {
+        return IconButton(
+          icon: icon,
+          color:
+              (tool == state.inputTool) ? Theme.of(context).primaryColor : null,
+          onPressed: () async {
+            if (tool == state.inputTool) {
+              switch (tool) {
+                case CorrectionInputTool.text:
+                  await showDialog(
+                      context: context,
+                      builder: (context) => const SimpleDialog(
+                            children: [TextSettingsWidget()],
+                          ));
+                  break;
+                case CorrectionInputTool.pencil:
+                  await showDialog(
+                      context: context,
+                      builder: (context) => const SimpleDialog(
+                            children: [PencilSettingsWidget()],
+                          ));
+                  break;
+                case CorrectionInputTool.marker:
+                  await showDialog(
+                      context: context,
+                      builder: (context) => const SimpleDialog(
+                            children: [MarkerSettingsWidget()],
+                          ));
+                  break;
+                case CorrectionInputTool.eraser:
+                  await showDialog(
+                      context: context,
+                      builder: (context) => const SimpleDialog(
+                            children: [EraserSettingsWidget()],
+                          ));
+                  break;
+              }
+            } else {
+              switch (tool) {
+                case CorrectionInputTool.text:
+                  BlocProvider.of<CorrectionOverlayCubit>(context)
+                      .changeTool(CorrectionInputTool.text);
+                  break;
+                case CorrectionInputTool.pencil:
+                  BlocProvider.of<CorrectionOverlayCubit>(context)
+                      .changeTool(CorrectionInputTool.pencil);
+                  break;
+                case CorrectionInputTool.marker:
+                  BlocProvider.of<CorrectionOverlayCubit>(context)
+                      .changeTool(CorrectionInputTool.marker);
+                  break;
+                case CorrectionInputTool.eraser:
+                  BlocProvider.of<CorrectionOverlayCubit>(context)
+                      .changeTool(CorrectionInputTool.eraser);
+                  break;
+              }
+            }
+          },
+        );
+      });
+}
+
+class _InputSettingsWidget extends StatelessWidget {
+  final CorrectionInputTool tool;
+
+  const _InputSettingsWidget({Key? key, required this.tool}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) =>
+      BlocBuilder<CorrectionOverlayCubit, CorrectionOverlayState>(
+          builder: (context, state) {
+        late final InputOptions options;
+        switch (tool) {
+          case CorrectionInputTool.eraser:
+            options = state.eraserOptions;
+            break;
+          case CorrectionInputTool.marker:
+            options = state.markerOptions;
+            break;
+          case CorrectionInputTool.pencil:
+            options = state.pencilOptions;
+            break;
+          case CorrectionInputTool.text:
+            options = state.textOptions;
+            break;
+        }
+
+        return Row(
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: VerticalDivider(
+                thickness: 2,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              child: Container(
+                height: options.size * 1.0,
+                width: 24,
+                decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12), color: Colors.black),
+              ),
+            ),
+            if (options is ColoredInputOptions)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: Icon(
+                  Icons.circle,
+                  color: options.color,
+                ),
+              ),
+          ],
+        );
+      });
 }

--- a/src/lib/components/correction/input/input_options.dart
+++ b/src/lib/components/correction/input/input_options.dart
@@ -1,5 +1,13 @@
 class InputOptions {
-  int size;
+  final int size;
 
-  InputOptions({required this.size});
+  const InputOptions({required this.size});
+
+  InputOptions copyWith({
+    int? size,
+  }) {
+    return InputOptions(
+      size: size ?? this.size,
+    );
+  }
 }

--- a/src/lib/components/correction/settings/color_picker_widget.dart
+++ b/src/lib/components/correction/settings/color_picker_widget.dart
@@ -1,0 +1,57 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+typedef ColorWidgetBuilder = Widget Function(
+    BuildContext context, Color color, bool selected);
+typedef ColorCallback = Function(Color color);
+
+class ColorPickerWidget extends StatefulWidget {
+  final List<Color> colors;
+  final ColorCallback? onSelected;
+  final ColorWidgetBuilder builder;
+  final Color? defaultValue;
+
+  const ColorPickerWidget(
+      {Key? key,
+      required this.colors,
+      required this.builder,
+      this.onSelected,
+      this.defaultValue})
+      : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _ColorPickerStateWidget();
+}
+
+class _ColorPickerStateWidget extends State<ColorPickerWidget> {
+  Color? selected;
+
+  @override
+  void initState() {
+    selected = widget.defaultValue;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) => Wrap(
+        children: List.generate(
+            widget.colors.length,
+            (index) => InkWell(
+                onTap: () {
+                  setState(() {
+                    selected = widget.colors[index];
+                    if (widget.onSelected != null) {
+                      widget.onSelected!(widget.colors[index]);
+                    }
+                  });
+                },
+                child: widget.builder(
+                    context,
+                    widget.colors[index],
+                    (selected == null)
+                        ? false
+                        : selected!.value == widget.colors[index].value))),
+      );
+}

--- a/src/lib/components/correction/settings/input_settings_widget.dart
+++ b/src/lib/components/correction/settings/input_settings_widget.dart
@@ -1,0 +1,101 @@
+import 'dart:math';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:schoolexam_correction_ui/components/correction/input/colored_input_options.dart';
+import 'package:schoolexam_correction_ui/components/correction/input/input_options.dart';
+
+import 'color_picker_widget.dart';
+
+typedef InputOptionsChangedCallback<T extends InputOptions> = void Function(
+    T options);
+
+class InputSettingsWidget<T extends InputOptions> extends StatefulWidget {
+  final InputOptionsChangedCallback<T> callback;
+  final T options;
+
+  const InputSettingsWidget(
+      {Key? key, required this.options, required this.callback})
+      : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _InputSettingsWidgetState();
+}
+
+class _InputSettingsWidgetState extends State<InputSettingsWidget> {
+  double? value;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        children: [
+          if (widget.options is ColoredInputOptions)
+            ColorPickerWidget(
+                defaultValue: (widget.options as ColoredInputOptions)
+                    .color
+                    .withAlpha(255),
+                colors: const [
+                  Colors.black,
+                  Colors.green,
+                  Colors.orange,
+                  Colors.yellow,
+                  Colors.red
+                ],
+                onSelected: (Color color) => widget.callback(
+                    (widget.options as ColoredInputOptions)
+                        .copyWith(color: color)),
+                builder: (BuildContext context, Color color, bool selected) =>
+                    Stack(
+                      children: [
+                        Icon(
+                          Icons.circle,
+                          color: color,
+                          size: (selected) ? 32 : 24,
+                        ),
+                        if (selected)
+                          const Padding(
+                            padding: EdgeInsets.all(4),
+                            child: Icon(
+                              Icons.check,
+                              size: 24,
+                              color: Colors.white,
+                            ),
+                          )
+                      ],
+                    )),
+          Row(
+            children: [
+              IconButton(
+                  onPressed: () {
+                    setState(() {
+                      value = max((value ?? widget.options.size * 1.0) - 1, 0);
+                    });
+                  },
+                  icon: const Icon(Icons.remove)),
+              CupertinoSlider(
+                min: 1,
+                max: 20,
+                thumbColor: (widget.options is ColoredInputOptions)
+                    ? (widget.options as ColoredInputOptions).color
+                    : Colors.black,
+                onChangeEnd: (double value) => widget
+                    .callback(widget.options.copyWith(size: value.toInt())),
+                value: value ?? widget.options.size * 1.0,
+                divisions: 50,
+                onChanged: (double value) {
+                  setState(() {
+                    this.value = value;
+                  });
+                },
+              ),
+              IconButton(
+                  onPressed: () {
+                    setState(() {
+                      value = min((value ?? widget.options.size * 1.0) + 1, 20);
+                    });
+                  },
+                  icon: const Icon(Icons.add)),
+            ],
+          )
+        ],
+      );
+}

--- a/src/lib/components/correction/settings/tool_settings_widget.dart
+++ b/src/lib/components/correction/settings/tool_settings_widget.dart
@@ -1,0 +1,78 @@
+import 'dart:math';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:schoolexam_correction_ui/blocs/overlay/correction_overlay.dart';
+import 'package:schoolexam_correction_ui/components/correction/input/colored_input_options.dart';
+import 'package:schoolexam_correction_ui/components/correction/input/drawing_input_options.dart';
+import 'package:schoolexam_correction_ui/components/correction/input/input_options.dart';
+
+import 'input_settings_widget.dart';
+
+class PencilSettingsWidget extends StatelessWidget {
+  const PencilSettingsWidget({Key? key}) : super(key: key);
+
+  void change(BuildContext context, DrawingInputOptions options) =>
+      BlocProvider.of<CorrectionOverlayCubit>(context)
+          .changePencilOptions(options);
+
+  @override
+  Widget build(BuildContext context) =>
+      BlocBuilder<CorrectionOverlayCubit, CorrectionOverlayState>(
+          builder: (context, state) => InputSettingsWidget<DrawingInputOptions>(
+                callback: <DrawingInputOptions>(options) =>
+                    change(context, options),
+                options: state.pencilOptions,
+              ));
+}
+
+class MarkerSettingsWidget extends StatelessWidget {
+  const MarkerSettingsWidget({Key? key}) : super(key: key);
+
+  void change(BuildContext context, DrawingInputOptions options) =>
+      BlocProvider.of<CorrectionOverlayCubit>(context)
+          .changeMarkerOptions(options);
+
+  @override
+  Widget build(BuildContext context) =>
+      BlocBuilder<CorrectionOverlayCubit, CorrectionOverlayState>(
+          builder: (context, state) => InputSettingsWidget<DrawingInputOptions>(
+                callback: <DrawingInputOptions>(options) =>
+                    change(context, options),
+                options: state.markerOptions,
+              ));
+}
+
+class TextSettingsWidget extends StatelessWidget {
+  const TextSettingsWidget({Key? key}) : super(key: key);
+
+  void change(BuildContext context, ColoredInputOptions options) =>
+      BlocProvider.of<CorrectionOverlayCubit>(context)
+          .changeTextOptions(options);
+
+  @override
+  Widget build(BuildContext context) =>
+      BlocBuilder<CorrectionOverlayCubit, CorrectionOverlayState>(
+          builder: (context, state) => InputSettingsWidget<ColoredInputOptions>(
+                callback: <ColoredInputOptions>(options) =>
+                    change(context, options),
+                options: state.textOptions,
+              ));
+}
+
+class EraserSettingsWidget extends StatelessWidget {
+  const EraserSettingsWidget({Key? key}) : super(key: key);
+
+  void change(BuildContext context, InputOptions options) =>
+      BlocProvider.of<CorrectionOverlayCubit>(context)
+          .changeEraserOptions(options);
+
+  @override
+  Widget build(BuildContext context) =>
+      BlocBuilder<CorrectionOverlayCubit, CorrectionOverlayState>(
+          builder: (context, state) => InputSettingsWidget<InputOptions>(
+                callback: <InputOptions>(options) => change(context, options),
+                options: state.eraserOptions,
+              ));
+}


### PR DESCRIPTION
# Added
- Input Widgets for all known input tools

# Changed
- Overlay cubit to emit more detailed states. This reduces the amount of unecessary builds of widgets, after just the input options are updated. (e.g. Reloading the pdf?)
- Structure of models and input options to properly encourage copyWith